### PR TITLE
Adjust build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,4 +123,5 @@ dist
 # Uploads and Transcripts (specific to this project)
 /uploads/
 /transcripts/
-/dist/node/ # Added for tsconfig.node.json output
+/dist/node/
+# Added for tsconfig.node.json output

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "concurrently \"vite\" \"nodemon server.js\"",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "start": "node server.js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,5 @@
     "outDir": "./dist", // Specify output directory for build artifacts (though Vite handles bundling)
     "rootDir": "./" // Specify root directory
   },
-  "include": ["src", "server.js", "vite.config.ts"], // Include server.js and vite.config.ts
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": ["src", "server.js", "vite.config.ts"] // Include server.js and vite.config.ts
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -3,14 +3,15 @@
     "composite": true,
     "skipLibCheck": true,
     "module": "ESNext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "strict": true,
     // "noEmit": true, // Remove noEmit when using composite/references that need declaration files
     "declaration": true, // Emit .d.ts files
     "declarationMap": true, // Emit source maps for .d.ts files
     "outDir": "dist/node", // Specify output directory for declaration files
-    "esModuleInterop": true // Ensure compatibility
+    "esModuleInterop": true, // Ensure compatibility
+    "types": ["node"]
   },
   "include": ["vite.config.ts"] // Specify files included in this specific config
 }


### PR DESCRIPTION
## Summary
- compile only with Vite during build
- remove project reference to node config
- set Node resolution and types for vite config project

## Testing
- `npm install` *(fails: ENOTEMPTY)*
- `npm run build` *(fails: vite not found)*